### PR TITLE
Fixed graphical error on edge attribute change

### DIFF
--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -1240,6 +1240,13 @@ SpriteMorph.prototype.setEdgeAttrib = function(attrib, edge, val) {
     // Run any relevant special handlers.
     if(EDGE_ATTR_HANDLERS[attrib] && EDGE_ATTR_HANDLERS[attrib].set) {
         EDGE_ATTR_HANDLERS[attrib].set.call(this, edge, data, val);
+
+        // Run handlers to ensure that the edge can be inputted in either order
+        // in an undirected graph.
+        if (!this.G.is_directed()){
+            var edge2 = new List([b, a]);
+            EDGE_ATTR_HANDLERS[attrib].set.call(this, edge2, data, val);
+        }
     }
 };
 

--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -327,7 +327,7 @@ function findNodeElement(node) {
 function findEdgeElement(edge) {
     var a = parseNode(edge.at(1)), b = parseNode(edge.at(2));
     return graphEl.selectAll(".edge").filter(function(d) {
-        return d.edge[0] === a && d.edge[1] === b;
+        return ((d.edge[0] === a && d.edge[1] === b) || (!currentGraph.is_directed()) && (d.edge[0] === b && d.edge[1] === a));
     });
 }
 
@@ -1240,13 +1240,6 @@ SpriteMorph.prototype.setEdgeAttrib = function(attrib, edge, val) {
     // Run any relevant special handlers.
     if(EDGE_ATTR_HANDLERS[attrib] && EDGE_ATTR_HANDLERS[attrib].set) {
         EDGE_ATTR_HANDLERS[attrib].set.call(this, edge, data, val);
-
-        // Run handlers to ensure that the edge can be inputted in either order
-        // in an undirected graph.
-        if (!this.G.is_directed()){
-            var edge2 = new List([b, a]);
-            EDGE_ATTR_HANDLERS[attrib].set.call(this, edge2, data, val);
-        }
     }
 };
 


### PR DESCRIPTION
I the graph is undirected, changing an edge attribute will update the appearance of the inputted edge as well as its reverse, ensuring that the order of nodes is irrelevant.
Resolves #244