### PR TITLE
Edgy can now both import graphs and subgraphs from files.

### DIFF
--- a/edgy.html
+++ b/edgy.html
@@ -45,6 +45,11 @@
 			var clickstream = new ClickstreamLogger(JSON.parse(localStorage['-snap-clickstream'] || "{}"));
 			var world = new WorldMorph(document.getElementById('world'));
 			var ide_ = new IDE_Morph();
+			
+			window.onerror = function(errorMessage, url, lineNumber) {
+			    ide_.parentThatIsA(IDE_Morph).showMessage(errorMessage);
+			}
+			
 			clickstream.log("sessionstart");
 		</script>
 		<script type="text/javascript" id="replace-me-pre">

--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -602,39 +602,12 @@ StageMorph.prototype.userMenu = (function changed (oldUserMenu) {
             submenu.popUpAtHand(world);
         });
 
-        menu.addItem("import from file", function () {
-            var inp = document.createElement('input');
-            inp.type = 'file';
-            inp.style.color = "transparent";
-            inp.style.backgroundColor = "transparent";
-            inp.style.border = "none";
-            inp.style.outline = "none";
-            inp.style.position = "absolute";
-            inp.style.top = "0px";
-            inp.style.left = "0px";
-            inp.style.width = "0px";
-            inp.style.height = "0px";
-            inp.addEventListener(
-                "change",
-                function () {
-                    document.body.removeChild(inp);
-                    var frd = new FileReader();
-                    var s = currentGraphSprite;
-                    frd.onloadend = function(e) {
-                        try {
-                            s.loadGraphFromString(e.target.result);
-                        } catch(e) {
-                            ide.showMessage("Error loading file: " + e.message);
-                        }
-                    }
-                    for (var i = 0; i < inp.files.length; i += 1) {
-                        frd.readAsText(inp.files[i]);
-                    }
-                },
-                false
-            );
-            document.body.appendChild(inp);
-            inp.click();
+        menu.addItem("import graph from file", function () {
+            currentGraphSprite.loadGraphFromFile(false);
+        });
+        
+        menu.addItem("import subgraph from file", function () {
+            currentGraphSprite.loadGraphFromFile(true);
         });
 
         return menu;
@@ -1691,9 +1664,9 @@ SpriteMorph.prototype.addAttrsFromGraph = function(graph) {
     });
 }
 
-SpriteMorph.prototype.loadGraphFromString = function(string) {
+SpriteMorph.prototype.loadGraphFromString = function(string, addTo) {
     try {
-        this.graphFromJSON(string, true);
+        this.graphFromJSON(string, addTo);
         return;
     } catch(e) {
         if(!(e instanceof SyntaxError)) {
@@ -1702,7 +1675,7 @@ SpriteMorph.prototype.loadGraphFromString = function(string) {
     }
 
     try {
-        this.importGraph(parseDot(string), true);
+        this.importGraph(parseDot(string), addTo);
         return;
     } catch(e) {
         if(!(e instanceof DotParser.SyntaxError)) {
@@ -1713,10 +1686,10 @@ SpriteMorph.prototype.loadGraphFromString = function(string) {
     var data = CSV.csvToArray(string);
     if(data[0][0] === '' || data[0][0] === null) {
         // Try parsing as adjacency matrix.
-        this.importGraph(parseAdjacencyMatrix(data), true);
+        this.importGraph(parseAdjacencyMatrix(data), addTo);
     } else {
         // Try parsing as adjacency list.
-        this.importGraph(parseAdjacencyList(data), true);
+        this.importGraph(parseAdjacencyList(data), addTo);
     }
 };
 
@@ -1725,11 +1698,46 @@ SpriteMorph.prototype.loadGraphFromURL = function(url) {
     request.open('GET', url, false);
     request.send(null);
     if (request.status === 200) {
-        this.loadGraphFromString(request.responseText);
+        this.loadGraphFromString(request.responseText, true);
     } else {
         throw new Error("Could not load URL: " + request.statusText);
     }
 };
+
+SpriteMorph.prototype.loadGraphFromFile = function(addTo) {
+    var inp = document.createElement('input');
+    inp.type = 'file';
+    inp.style.color = "transparent";
+    inp.style.backgroundColor = "transparent";
+    inp.style.border = "none";
+    inp.style.outline = "none";
+    inp.style.position = "absolute";
+    inp.style.top = "0px";
+    inp.style.left = "0px";
+    inp.style.width = "0px";
+    inp.style.height = "0px";
+    inp.addEventListener(
+        "change",
+        function () {
+            document.body.removeChild(inp);
+            var frd = new FileReader();
+            var s = currentGraphSprite;
+            frd.onloadend = function(e) {
+                try {
+                    s.loadGraphFromString(e.target.result, addTo);
+                } catch(e) {
+                    throw new Error("Error loading file: " + e.message);
+                }
+            }
+            for (var i = 0; i < inp.files.length; i += 1) {
+                frd.readAsText(inp.files[i]);
+            }
+        },
+        false
+    );
+    document.body.appendChild(inp);
+    inp.click();
+}
 
 SpriteMorph.prototype.topologicalSort = function() {
     return new List(jsnx.algorithms.dag.topological_sort(this.G));


### PR DESCRIPTION
Importing a graph replaces the existing one on screen, while importing a disjoint subgraph will add it instead. Edgy also now displays error messages by listening to thrown global errors (via window.onerror).