### PR TITLE
Fix serialization and loading of MultiArgPairsMorph

### DIFF
--- a/edgy/collections.js
+++ b/edgy/collections.js
@@ -51,6 +51,12 @@ MultiArgPairsMorph.prototype.removeInput = function(contents) {
         this.removeChild(oldPart);
     }
 };
+MultiArgPairsMorph.prototype.toXML = function (serializer) {
+    return serializer.format(
+        '<pairs>%</pairs>',
+        serializer.store(this.inputs())
+    );
+};
 
 /**
 MapMorph, a morph representing Map object outputs.

--- a/store.js
+++ b/store.js
@@ -1053,6 +1053,23 @@ SnapSerializer.prototype.loadInput = function (model, input, block) {
             );
         });
         input.fixLayout();
+    } else if (model.tag === 'pairs') {
+        while (input.inputs().length > 0) {
+            input.removeInput();
+        }
+		var i = 0;
+        model.children.forEach(function (item) {
+            if (i % 2 == 0) {
+				input.addInput();
+            }
+			myself.loadInput(
+                item,
+                input.children[input.children.length - 3 + (i % 2)],
+                input
+            );
+			i++;
+        });
+        input.fixLayout();
     } else if (model.tag === 'block' || model.tag === 'custom-block') {
         block.silentReplaceInput(input, this.loadBlock(model, true));
     } else if (model.tag === 'color') {


### PR DESCRIPTION
This PR fixes saving and loading of dictionaries and counters

Now deals with the pairs of inputs correctly for MultiArgPairsMorph types by making the MultiArgPairsMorph output `<pairs>%</pairs>` instead of `<list>%</list>` and dealing with the pairs tag appropriately.

Files that were exported/saved before will still load as before (ie, incorrectly).

I'm not sure if I'm editing things in the right places, but this fixes #251.