### PR TITLE
Add serialization/deserialiazation support for Map type

### DIFF
--- a/edgy/changesToStore.js
+++ b/edgy/changesToStore.js
@@ -39,4 +39,31 @@ SnapSerializer.prototype.loadObject = (function loadObject (oldLoadObject) {
     };
 }(SnapSerializer.prototype.loadObject));
 
+Map.prototype.toXML = function (serializer, mediaContext) {
+    var xml = '';
+    this.forEach(function(value, key) {
+        var k = serializer.format(
+            '<key>%</key>',
+            typeof key === 'object' ?
+                    serializer.store(key, mediaContext)
+                    : typeof key === 'boolean' ?
+                            serializer.format('<bool>$</bool>', key)
+                            : serializer.format('<l>$</l>', key)
+        );
+        
+        var v = serializer.format(
+            '<value>%</value>',
+            typeof value === 'object' ?
+                    serializer.store(value, mediaContext)
+                    : typeof value === 'boolean' ?
+                            serializer.format('<bool>$</bool>', value)
+                            : serializer.format('<l>$</l>', value)
+        );
+        
+        xml += k + v;
+    });
+    
+    return serializer.format('<map>%</map>', xml);
+};
+
 }());

--- a/store.js
+++ b/store.js
@@ -1153,6 +1153,27 @@ SnapSerializer.prototype.loadValue = function (model) {
             return myself.loadValue(value);
         });
         return v;
+    case 'map':
+        var res = new Map();
+        var myself = this;
+        keys = model.childrenNamed('key').map(function (item) {
+            var value = item.children[0];
+            if (!value) {
+                return 0;
+            }
+            return myself.loadValue(value);
+        });
+        values = model.childrenNamed('value').map(function (item) {
+            var value = item.children[0];
+            if (!value) {
+                return 0;
+            }
+            return myself.loadValue(value);
+        });
+        for (var i = 0; i < keys.length; i++) {
+            res.set(keys[i], values[i]);
+        }
+        return res;
     case 'sprite':
         v  = new SpriteMorph(myself.project.globalVariables);
         if (model.attributes.id) {


### PR DESCRIPTION
Stores variables containing dictionaries and counters correctly.

Adds `toXML()` method to Map prototype.
Handles maps when loading values.

Fixes #254.