### PR TITLE
Make nodes fixed when switching to manual layout

### DIFF
--- a/edgy/changesToGui.js
+++ b/edgy/changesToGui.js
@@ -224,6 +224,9 @@ IDE_Morph.prototype.toggleUseManualLayout = function () {
         this.useManualLayout = false;
         this.currentSprite.resumeLayout();
     } else {
+        jsnx.forEach(currentGraph.nodes_iter(true), function(node) {
+            node[1].__d3datum__.fixed = true;
+        });
         this.useManualLayout = true;
     }
 }


### PR DESCRIPTION
Goes through all the nodes and sets each of the to be fixed immediately upon switching to Use manual layout instead of fixing each node only upon the using moving them.

Fixes #259.