### PR TITLE
setActiveGraph when creating stage

### DIFF
--- a/edgy/changesToGui.js
+++ b/edgy/changesToGui.js
@@ -36,6 +36,9 @@ IDE_Morph.prototype.createStage = (function createStage (oldCreateStage) {
     return function () {
         var retval = oldCreateStage.call(this);
         this.emptyStageString = this.serializer.serialize(this.stage);
+        if (this.currentSprite instanceof SpriteMorph) {
+            this.currentSprite.setActiveGraph();
+        }
         return retval;
     }
 }(IDE_Morph.prototype.createStage));


### PR DESCRIPTION
This clears the stage graph when replacing the project with a new one.

Currently the graph is destroyed internally upon creating a new project but still shown on the stage, and on top of that, the new graph and graph generator blocks appear to stop working until the 'show' block is executed. This commit fixes the issue.