### PR TITLE
Destroy old morph before adding new one

### DIFF
--- a/edgy/collections.js
+++ b/edgy/collections.js
@@ -477,20 +477,22 @@ CellMorph.prototype.drawNew = (function() {
 
     return function () {
         if (this.contents instanceof Map) {
+            if (this.contentsMorph) {
+                this.contentsMorph.destroy();
+            }
             this.contentsMorph = new MapMorph(this.contents, this);
             this.contentsMorph.isDraggable = false;
             this.contents = this.contentsMorph;
-            oldDrawNew.call(this);
         }
         else if (this.contents instanceof PriorityQueue) {
+            if (this.contentsMorph) {
+                this.contentsMorph.destroy();
+            }
             this.contentsMorph = new PriorityQueueMorph(this.contents, this);
             this.contentsMorph.isDraggable = false;
             this.contents = this.contentsMorph;
-            oldDrawNew.call(this);
         }
-        else {
-            oldDrawNew.call(this);
-        }
+        oldDrawNew.call(this);
     };
 })();
 


### PR DESCRIPTION
Prevents old MapMorph and PriorityQueueMorph instance from remaining when setting a variable to a new Map or new PriorityQueue.

Currently if you have a variable and set it to a dict or a pqueue twice, the previous watcher morph will get stuck and remain there until the variable is deleted. This fixes the issue.