### PR TITLE
Add import/export of global variables

### DIFF
--- a/edgy.html
+++ b/edgy.html
@@ -32,6 +32,7 @@
 		<script type="text/javascript" src="edgy/changesToStore.js"></script>
 		<script type="text/javascript" src="edgy/changesToGui.js"></script>
 		<script type="text/javascript" src="edgy/collections.js"></script>
+		<script type="text/javascript" src="edgy/variables.js"></script>
 		<script type="text/javascript" src="dotparser.js"></script>
 		<script type="text/javascript" src="dotgraph.js"></script>
 		<script type="text/javascript" src="jsonp.js"></script>

--- a/edgy/variables.js
+++ b/edgy/variables.js
@@ -1,0 +1,347 @@
+(function() {
+"use strict";
+
+IDE_Morph.prototype.exportGlobalVariables = function() {
+    if (this.globalVariables.allNames().length > 0) {
+        new VariableExportDialogMorph(
+            this.serializer,
+            this.globalVariables
+        ).popUp(this.world());
+    }
+    else {
+        this.inform(
+            'Export Variables',
+            'this project doesn\'t have any\n'
+                + 'global variables yet'
+        );
+    }
+}
+
+
+IDE_Morph.prototype.openVariablesString = function (str) {
+    var msg,
+        myself = this;
+    this.nextSteps([
+        function () {
+            msg = myself.showMessage('Opening variables...');
+        },
+        function () {
+            myself.rawOpenVariablesString(str);
+        },
+        function () {
+            msg.destroy();
+        }
+    ]);
+};
+
+IDE_Morph.prototype.rawOpenVariablesString = function (str) {
+    var xml = this.serializer.parse(str);
+    if (Process.prototype.isCatchingErrors) {
+        try {
+            this.serializer.loadVariables(this.globalVariables, xml);
+            this.flushBlocksCache('variables');
+            this.refreshPalette();
+        } catch (err) {
+            this.showMessage('Load failed: ' + err);
+        }
+    } else {
+        this.serializer.loadVariables(this.globalVariables, xml);
+        this.flushBlocksCache('variables');
+        this.refreshPalette();
+    }
+};
+
+}());
+
+// VariableExportDialogMorph ////////////////////////////////////////////////////
+
+// VariableExportDialogMorph inherits from DialogBoxMorph:
+
+VariableExportDialogMorph.prototype = new DialogBoxMorph();
+VariableExportDialogMorph.prototype.constructor = VariableExportDialogMorph;
+VariableExportDialogMorph.uber = DialogBoxMorph.prototype;
+
+// VariableExportDialogMorph constants:
+
+VariableExportDialogMorph.prototype.key = 'variableExport';
+
+// VariableExportDialogMorph instance creation:
+
+function VariableExportDialogMorph(serializer, vars) {
+    this.init(serializer, vars);
+}
+
+VariableExportDialogMorph.prototype.init = function (serializer, varFrame) {
+    var myself = this;
+
+    // additional properties:
+    this.serializer = serializer;
+    this.varFrame = varFrame;
+    this.variables = [];
+    this.handle = null;
+    
+    // initialize inherited properties:
+    VariableExportDialogMorph.uber.init.call(
+        this,
+        null, // target
+        function () {myself.exportVariables(); },
+        null // environment
+    );
+ 
+    // override inherited properites:
+    this.labelString = 'Export variables';
+    this.createLabel();
+
+    // build contents
+    this.buildContents();
+};
+
+VariableExportDialogMorph.prototype.buildContents = function () {
+    var palette, x, y, block, checkBox, lastCat,
+        myself = this,
+        padding = 4;
+
+    // create plaette
+    palette = new ScrollFrameMorph(
+        null,
+        null,
+        SpriteMorph.prototype.sliderColor
+    );
+    palette.color = SpriteMorph.prototype.paletteColor;
+    palette.padding = padding;
+    palette.isDraggable = false;
+    palette.acceptsDrops = false;
+    palette.contents.acceptsDrops = false;
+
+    // populate palette
+    x = palette.left() + padding;
+    y = palette.top() + padding;
+    
+    myself.varFrame.allNames().forEach(function (varName) {
+        block = SpriteMorph.prototype.variableBlock(varName);
+        block.isDraggable = false;
+        block.isTemplate = true;
+        
+        checkBox = new ToggleMorph(
+            'checkbox',
+            myself,
+            function () {
+                var idx = myself.variables.indexOf(varName);
+                if (idx > -1) {
+                    myself.variables.splice(idx, 1);
+                }
+                else {
+                    myself.variables.push(varName);
+                }
+            },
+            null,
+            function () {
+                return contains(
+                    myself.variables,
+                    varName
+                );
+            },
+            null,
+            null,
+            null,
+            block.fullImage()
+        );
+        checkBox.setPosition(new Point(
+            x,
+            y + (checkBox.top() - checkBox.toggleElement.top())
+        ));
+        palette.addContents(checkBox);
+        y += checkBox.fullBounds().height() + padding;
+        
+    });
+
+    palette.scrollX(padding);
+    palette.scrollY(padding);
+    this.addBody(palette);
+
+    this.addButton('ok', 'OK');
+    this.addButton('cancel', 'Cancel');
+
+    this.setExtent(new Point(220, 300));
+    this.fixLayout();
+
+};
+
+VariableExportDialogMorph.prototype.popUp = function (wrrld) {
+    var world = wrrld || this.target.world();
+    if (world) {
+        VariableExportDialogMorph.uber.popUp.call(this, world);
+        this.handle = new HandleMorph(
+            this,
+            200,
+            220,
+            this.corner,
+            this.corner
+        );
+    }
+};
+
+// VariableExportDialogMorph menu
+
+VariableExportDialogMorph.prototype.userMenu = function () {
+    var menu = new MenuMorph(this, 'select');
+    menu.addItem('all', 'selectAll');
+    menu.addItem('none', 'selectNone');
+    return menu;
+};
+
+VariableExportDialogMorph.prototype.selectAll = function () {
+    this.body.contents.children.forEach(function (checkBox) {
+        if (!checkBox.state) {
+            checkBox.trigger();
+        }
+    });
+};
+
+VariableExportDialogMorph.prototype.selectNone = function () {
+    this.blocks = [];
+    this.body.contents.children.forEach(function (checkBox) {
+        checkBox.refresh();
+    });
+};
+
+// VariableExportDialogMorph ops
+
+VariableExportDialogMorph.prototype.exportVariables = function () {
+    var myself = this;
+    var serializer = this.serializer;
+    
+    var str = this.variables.reduce(function (vars, v) {
+        var val = myself.varFrame.vars[v],
+            dta;
+        
+        if (val === undefined || val === null) {
+            dta = serializer.format('<variable name="@"/>', v);
+        } else {
+            dta = serializer.format(
+                '<variable name="@">%</variable>',
+                v,
+                typeof val === 'object' ? serializer.store(val)
+                        : typeof val === 'boolean' ?
+                                serializer.format('<bool>$</bool>', val)
+                                : serializer.format('<l>$</l>', val)
+            );
+        }
+        return vars + dta;
+    }, '');
+    
+    if (this.variables.length > 0) {
+        window.open(encodeURI('data:text/xml,<variables app="'
+            + this.serializer.app
+            + '" version="'
+            + this.serializer.version
+            + '">'
+            + str
+            + '</variables>'));
+    } else {
+        new DialogBoxMorph().inform(
+            'Export variables',
+            'no variables were selected',
+            this.world()
+        );
+    }
+};
+
+// VariableExportDialogMorph layout
+
+VariableExportDialogMorph.prototype.fixLayout
+    = BlockEditorMorph.prototype.fixLayout;
+
+// VariableImportDialogMorph ////////////////////////////////////////////////////
+
+// VariableImportDialogMorph inherits from DialogBoxMorph
+// and pseudo-inherits from VariableExportDialogMorph:
+
+/*
+VariableImportDialogMorph.prototype = new DialogBoxMorph();
+VariableImportDialogMorph.prototype.constructor = VariableImportDialogMorph;
+VariableImportDialogMorph.uber = DialogBoxMorph.prototype;
+
+// VariableImportDialogMorph constants:
+
+VariableImportDialogMorph.prototype.key = 'blockImport';
+
+// VariableImportDialogMorph instance creation:
+
+function VariableImportDialogMorph(blocks, target, name) {
+    this.init(blocks, target, name);
+}
+
+VariableImportDialogMorph.prototype.init = function (blocks, target, name) {
+    var myself = this;
+
+    // additional properties:
+    this.blocks = blocks.slice(0);
+    this.handle = null;
+
+    // initialize inherited properties:
+    VariableExportDialogMorph.uber.init.call(
+        this,
+        target,
+        function () {myself.importBlocks(name); },
+        null // environment
+    );
+
+    // override inherited properites:
+    this.labelString = localize('Import blocks')
+        + (name ? ': ' : '')
+        + name || '';
+    this.createLabel();
+
+    // build contents
+    this.buildContents();
+};
+
+VariableImportDialogMorph.prototype.buildContents
+    = VariableExportDialogMorph.prototype.buildContents;
+
+VariableImportDialogMorph.prototype.popUp
+    = VariableExportDialogMorph.prototype.popUp;
+
+// VariableImportDialogMorph menu
+
+VariableImportDialogMorph.prototype.userMenu
+    = VariableExportDialogMorph.prototype.userMenu;
+
+VariableImportDialogMorph.prototype.selectAll
+    = VariableExportDialogMorph.prototype.selectAll;
+
+VariableImportDialogMorph.prototype.selectNone
+    = VariableExportDialogMorph.prototype.selectNone;
+
+// VariableImportDialogMorph ops
+
+VariableImportDialogMorph.prototype.importBlocks = function (name) {
+    var ide = this.target.parentThatIsA(IDE_Morph);
+    if (!ide) {return; }
+    if (this.blocks.length > 0) {
+        this.blocks.forEach(function (def) {
+            def.receiver = ide.stage;
+            ide.stage.globalBlocks.push(def);
+            ide.stage.replaceDoubleDefinitionsFor(def);
+        });
+        ide.flushPaletteCache();
+        ide.refreshPalette();
+        ide.showMessage(
+            'Imported Variable Module' + (name ? ': ' + name : '') + '.',
+            2
+        );
+    } else {
+        new DialogBoxMorph().inform(
+            'Import variables',
+            'no variables were selected',
+            this.world()
+        );
+    }
+};
+
+// VariableImportDialogMorph layout
+
+VariableImportDialogMorph.prototype.fixLayout
+    = BlockEditorMorph.prototype.fixLayout;
+*/

--- a/gui.js
+++ b/gui.js
@@ -1566,6 +1566,9 @@ IDE_Morph.prototype.droppedText = function (aString, name) {
     if (aString.indexOf('<blocks') === 0) {
         return this.openBlocksString(aString, lbl, true);
     }
+	if (aString.indexOf('<variables') === 0) {
+        return this.openVariablesString(aString);
+    }
     if (aString.indexOf('<sprites') === 0) {
         return this.openSpritesString(aString);
     }
@@ -2402,6 +2405,12 @@ IDE_Morph.prototype.projectMenu = function () {
         'Export blocks...',
         function () {myself.exportGlobalBlocks(); },
         'show global custom block definitions as XML\nin a new browser window'
+    );
+
+    menu.addItem(
+        'Export variables...',
+        function () { myself.exportGlobalVariables(); },
+        'show global variables in a new browser window'
     );
 
     if (shiftClicked) {


### PR DESCRIPTION
This PR adds the ability to import/export global variables separately from projects.

This allows variables to be more easily exported for other programs to use (e.g. list/dict data can be opened in Excel and graphed). The bottom part of the file is commented out because it was part of the block importer this was adapted from, but never seems to get used.