### PR TITLE
Add copy and paste support

### DIFF
--- a/edgy.html
+++ b/edgy.html
@@ -40,6 +40,7 @@
 		<script type="text/javascript" src="Blob.js"></script>
 		<script type="text/javascript" src="FileSaver.js"></script>
 		<script type="text/javascript" src="edgy/changesToMorphic.js"></script>
+		<script type="text/javascript" src="edgy/clipboard.js"></script>
 		<script type="text/javascript" src="edgy/resigclass.js"></script>
 		<script type="text/javascript" src="edgy/clickstream.js"></script>
 		<script type="text/javascript">

--- a/edgy/clipboard.js
+++ b/edgy/clipboard.js
@@ -1,0 +1,68 @@
+(function() {
+"use strict";
+
+CursorMorph.prototype.init = (function(oldInit) {
+    return function(aStringOrTextMorph) {
+        oldInit.call(this, aStringOrTextMorph);
+        
+        // Add hidden text box for copying and pasting
+        var myself = this;
+        
+        // Hidden div allows the browser to focus on the text box
+        this.hiddenDiv = document.createElement('div');
+        this.hiddenDiv.style.position = "absolute";
+        this.hiddenDiv.style.right = "101%"; // placed just out of view
+        
+        // The text box
+        this.hiddenText = document.createElement('textarea');
+        this.target.hiddenText = this.hiddenText;
+        
+        this.hiddenDiv.appendChild(this.hiddenText);
+        document.body.appendChild(this.hiddenDiv);
+        
+        this.hiddenText.value = this.target.selection();
+        this.hiddenText.focus();
+        this.hiddenText.select();
+        
+        this.hiddenText.addEventListener(
+            "keypress",
+            function (event) {
+                myself.processKeyPress(event);
+                this.value = myself.target.selection();
+                this.select();
+            },
+            false
+        );
+        
+        this.hiddenText.addEventListener(
+            "keydown",
+            function (event) {
+                myself.processKeyDown(event);
+                this.value = myself.target.selection();
+                this.select();
+            },
+            false
+        );
+        
+        this.hiddenText.addEventListener(
+            "input",
+            function (event) {
+                if (this.value == "") {
+                    myself.gotoSlot(myself.target.selectionStartSlot());
+                    myself.target.deleteSelection();
+                }
+            },
+            false
+        );
+    };
+}(CursorMorph.prototype.init));
+
+CursorMorph.prototype.destroy = (function(oldDestroy) {
+    return function() {
+        oldDestroy.call(this);
+        if (this.hiddenText)
+            document.body.removeChild(this.hiddenDiv);
+    };
+}(CursorMorph.prototype.destroy));
+
+}());


### PR DESCRIPTION
Uses a hidden textarea for copy, cut and paste support.

I'm not sure if there's a better way to do this, but hidden textboxes seem to be the only way to get browser to support copy and paste (the alternative is to use Flash, but that doesn't seem appropriate).