### PR TITLE
Fix tab focussing for CursorMorph

### DIFF
--- a/edgy/clipboard.js
+++ b/edgy/clipboard.js
@@ -40,6 +40,12 @@ CursorMorph.prototype.init = (function(oldInit) {
                 myself.processKeyDown(event);
                 this.value = myself.target.selection();
                 this.select();
+                
+                // Make sure tab prevents default
+                if (event.keyIdentifier === 'U+0009' || event.keyIdentifier === 'Tab') {
+                    myself.processKeyPress(event);
+                    event.preventDefault();
+                }
             },
             false
         );


### PR DESCRIPTION
Stops canvas from losing focus on pressing tab in Chrome