### PR TITLE
Fix for issue #274

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -1738,6 +1738,9 @@ IDE_Morph.prototype.applySavedSettings = function () {
         longform = this.getSetting('longform'),
         plainprototype = this.getSetting('plainprototype');
 
+    // Principle of least privilege: JavaScript block execution is disabled unless the user requires it for this particular session.
+    window.javascriptexecutionlevel = 'blocked';
+    
     // design
     if (design === 'flat') {
         this.setFlatDesign();
@@ -2137,6 +2140,7 @@ IDE_Morph.prototype.settingsMenu = function () {
         'Stage size...',
         'userSetStageSize'
     );
+    menu.addItem('Execution privileges...', 'javaScriptExecutionLevelMenu');
     menu.addLine();
     addPreference(
         'Blurred shadows',
@@ -3439,6 +3443,21 @@ IDE_Morph.prototype.languageMenu = function () {
     });
     menu.popup(world, pos);
 };
+
+IDE_Morph.prototype.javaScriptExecutionLevelMenu = function() {
+    var menu = new MenuMorph(this),
+        world = this.world(),
+        pos = this.controlBar.settingsButton.bottomLeft(),
+        myself = this;
+    menu.addItem((window.javascriptexecutionlevel === 'full' ? '\u2713 ' : '    ')+'full', function() {
+        alert('You have given the current project permission to execute code at the same level as Edgy itself -- code within "JavaScript function" blocks will have access to all Edgy functionality, including modifying local storage and accessing cloud storage credentials. If you do not trust the author of this project, set the "Execution privileges" permission setting to a lower value.');
+        window.javascriptexecutionlevel = 'full';
+    });
+    menu.addItem((window.javascriptexecutionlevel === 'blocked' ? '\u2713 ' : '    ')+'blocked', function() {
+        window.javascriptexecutionlevel = 'blocked'; }
+    );
+    menu.popup(world, pos);
+}
 
 IDE_Morph.prototype.setLanguage = function (lang, callback) {
     var translation = document.getElementById('language'),

--- a/threads.js
+++ b/threads.js
@@ -764,10 +764,14 @@ Process.prototype.reifyPredicate = function (topBlock, parameterNames) {
 };
 
 Process.prototype.reportJSFunction = function (parmNames, body) {
-    return Function.apply(
-        null,
-        parmNames.asArray().concat([body])
-    );
+    if (window.javascriptexecutionlevel === 'full') {
+        return Function.apply(
+            null,
+            parmNames.asArray().concat([body])
+        );
+    } else {
+        throw new Error('The current script attempted to execute JavaScript code at a higher privilege level than is currently allowed.\nCode execution was terminated.\nIf you trust the code within the JavaScript blocks and wish to execute it, set the "Execution level" setting to the appropriate level.');
+    }
 };
 
 Process.prototype.doRun = function (context, args, isCustomBlock) {


### PR DESCRIPTION
This commit prevents JavaScript blocks from executing and adds a menu option to explicitly allow JavaScript block execution. This commit will throw the user an error (via the Snap! error dialog) if they run a script containing JavaScript-block code without explicitly allowing JavaScript block execution. Currently, the "Execution privileges" menu only has two settings -- blocked or given full access -- but it can be expanded later to allow a finer range of privilege control, if/when sandboxing is implemented for the JavaScript function block.