### PR TITLE
Reset numbering of nodes on new graph/digraph

### DIFF
--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -774,10 +774,12 @@ function parseNode(node) {
 // Graph block bindings
 
 SpriteMorph.prototype.newGraph = function() {
+    this.maximumNode = 0;
     this.setGraph(jsnx.Graph());
 };
 
 SpriteMorph.prototype.newDiGraph = function() {
+    this.maximumNode = 0;
     this.setGraph(jsnx.DiGraph());
 };
 


### PR DESCRIPTION
Restarts numbering of new nodes when using new graph/new digraph.

Fixes #278