### PR TITLE
Extends JavaScript-function blocking to Function reporters in 'run' and 'call' blocks

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -785,10 +785,15 @@ Process.prototype.evaluate = function (
 ) {
     if (!context) {return null; }
     if (context instanceof Function) {
-        return context.apply(
-            this.homeContext.receiver,
-            args.asArray().concat([this])
-        );
+        // ALL calls to eval(), Function.apply() etc.. need to be handled this way, otherwise there will be a way to inject JS code..
+        if (window.javascriptexecutionlevel === 'full') {
+            return context.apply(
+                this.homeContext.receiver,
+                args.asArray().concat([this])
+            );
+        } else {
+            throw new Error('The current script attempted to execute JavaScript code at a higher privilege level than is currently allowed.\nCode execution was terminated.\nIf you trust the code within the JavaScript blocks and wish to execute it, set the "Execution level" setting to the appropriate level.');
+        }
     }
     if (context.isContinuation) {
         return this.runContinuation(context, args);


### PR DESCRIPTION
This PR is an extension of my previous one which blocked execution of user-generated JavaScript code by default. The previous PR blocked *parsing* JavaScript reporter blocks, but did not prevent a run or call block from executing previously parsed JavaScript.

The attack vector that this commit addresses involves a malicious user setting Execution Privileges to full on their computer, saving the malicious JavaScript to a variable, and only referencing the code by name in a 'call' block -- no JavaScript function block required in the exported file. The code would run on the victim's computer regardless on their own Execution Privileges setting. Incidentally, there is currently a bug in edgy that prevents this from happening -- a Function variable exported to XML becomes a string that looks something like "function anonymous() { // code here }", which is not parsed correctly and hence cannot be used to get around the Execution Privileges checker.

Nevertheless, I think it is worth fixing, since relying on a bug for security is very much bad practice. To put the issue in more concrete terms:

Input: Set Execution Privileges to 'full' -> Set variable to JavaScript function block -> Set Execution Privileges to 'blocked' -> Run variable as code in run/call block

Output on master branch: Code is executed

Output with proposed changes: Error is thrown, code is not executed