### PR TITLE
Add export of block sequences

### DIFF
--- a/edgy/changesToBlocks.js
+++ b/edgy/changesToBlocks.js
@@ -49,4 +49,49 @@ PenMorph.prototype.drawNew = function (facing) {
     SymbolMorph.prototype.drawSymbolTurtle(this.image, this.color.toString());
 };
 
+BlockMorph.prototype.userMenu = (function(oldUserMenu) {
+    return function() {
+        var myself = this,
+            menu = oldUserMenu.call(this);
+        if (!this.isTemplate) {
+            menu.addLine();
+            menu.addItem(
+                "export...",
+                function () {
+                    var exportSequence = function() {
+                        var serializer = myself.parentThatIsA(IDE_Morph).serializer;
+                        var xml = myself.topBlock().toScriptXML(serializer);
+                        window.open("data:text/xml," + xml);
+                    };
+                    
+                    var block = myself.topBlock();
+                    var hasCustomBlock = false;
+                    
+                    while (block instanceof BlockMorph) {
+                        if (block instanceof CustomCommandBlockMorph || block instanceof CustomReporterBlockMorph) {
+                            hasCustomBlock = true;
+                            break;
+                        }
+                        block = block.nextBlock ? block.nextBlock() : null;
+                    }
+                    
+                    if (hasCustomBlock) {
+                        this.parentThatIsA(IDE_Morph).confirm(
+                            "This sequence contains a custom block whose definition will not be exported. Continue?",
+                            "Block sequence export",
+                            exportSequence
+                        );
+                    }
+                    else {
+                        exportSequence();
+                    }
+                   
+                },
+                'open a new window\nwith this block sequence as XML'
+            );
+        }
+        return menu;
+    };
+}(BlockMorph.prototype.userMenu));
+
 }());

--- a/edgy/changesToGui.js
+++ b/edgy/changesToGui.js
@@ -280,4 +280,52 @@ IDE_Morph.prototype.rawOpenBlocksString = (function(oldRawOpenBlocksString) {
     };
 }(IDE_Morph.prototype.rawOpenBlocksString));
 
+IDE_Morph.prototype.openBlockSequenceString = function (str) {
+    var msg,
+        myself = this;
+    this.nextSteps([
+        function () {
+            msg = myself.showMessage('Opening block sequence...');
+        },
+        function () {
+            myself.rawOpenBlockSequenceString(str);
+        },
+        function () {
+            msg.destroy();
+        }
+    ]);
+};
+
+IDE_Morph.prototype.rawOpenBlockSequenceString = function (str) {
+    var myself = this;
+    var xml = this.serializer.parse(str);
+    var importSequence = function(model) {
+        var script = myself.serializer.loadScript(model);
+        script.pickUp(world);
+        world.hand.grabOrigin = {
+            origin: myself.palette,
+            position: myself.palette.center()
+        };
+    };
+    
+    if (Process.prototype.isCatchingErrors) {
+        try {
+            importSequence(xml);
+        } catch (err) {
+            this.showMessage('Load failed: ' + err);
+        }
+    } else {
+        importSequence(xml);
+    }
+};
+
+IDE_Morph.prototype.droppedText = (function(oldDroppedText) {
+    return function(aString, name) {
+        if (aString.indexOf('<script') === 0) {
+            return this.openBlockSequenceString(aString);
+        }
+        return oldDroppedText.call(this, aString, name);
+    };
+}(IDE_Morph.prototype.droppedText));
+
 }());

--- a/gui.js
+++ b/gui.js
@@ -307,7 +307,7 @@ IDE_Morph.prototype.openIn = function (world) {
                 hash = decodeURIComponent(hash);
             }
             if (contains(
-                    ['project', 'blocks', 'sprites', 'snapdata'].map(
+                    ['project', 'blocks', 'sprites', 'snapdata', 'variables', 'script'].map(
                         function (each) {
                             return hash.substr(0, 8).indexOf(each);
                         }


### PR DESCRIPTION
Right clicking a block sequence now allows the block sequence to be exported (and imported through the file menu).

A warning is now given if exporting a custom block definition or a block sequence may cause unmet dependencies.

Closes #293.