### PR TITLE
Allow change of node shape, outline colour/size and label color, expose label attribute

### DIFF
--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -1083,6 +1083,13 @@ var NODE_ATTR_HANDLERS = {
             }
         }
     },
+    label: {
+        default: "",
+        set: function(node, data, val) {
+            if (val == "")
+                delete data.label;
+        }
+    },
     "label-color": {
         default: DEFAULT_LABEL_COLOR,
         set: function(node, data, val) {
@@ -1186,17 +1193,20 @@ SpriteMorph.prototype.setNodeAttrib = function(attrib, node, val) {
     var data = this.G.node.get(node);
     data[attrib] = val;
 
-    // Handle situation where changed attribute is the one being displayed
-    if (attrib === currentGraph.nodeDisplayAttribute) {
-        if (data.__d3datum__) {
-            findNodeElement(node).select('text').text(val);
-            findNodeElement(node).select('text').style("fill" , "black");
-        }
-    }
-
     // Run any relevant special handlers.
     if(NODE_ATTR_HANDLERS[attrib] && NODE_ATTR_HANDLERS[attrib].set) {
         NODE_ATTR_HANDLERS[attrib].set.call(this, node, data, val);
+    }
+    
+    // Handle situation where changed attribute is the one being displayed
+    if (attrib === currentGraph.nodeDisplayAttribute) {
+        if (data.__d3datum__) {
+            var nodeElement = findNodeElement(node);
+            updateNodeAppearance(nodeElement);
+            nodeElement.select('text')
+                .text(data[attrib] || node)
+                .style(LAYOUT_OPTS.label_style);
+        }
     }
 };
 


### PR DESCRIPTION
Allows the user to change the shape of a node to 'circle' or 'ellipse' (default is 'rect').
Allows the user to change the colour of a node outline (stroke).
Allows the user to change the width of a node outline (stroke-width).
Allows the user to change the colour of a node/edge label (label-color).

This also exposes the 'label' node attribute. This has always been present, but until now could not be changed by the user (unless they made a custom node attribute that happened to be called label). This facilitates the hiding of node labels for #317 (setting them to whitespace).

Closes #302.
Closes #303.