### PR TITLE
Move add blocks to the initBlocks function

### DIFF
--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -2896,12 +2896,20 @@ SpriteMorph.prototype.loadGraph = function (handle) {
         }
     };
 
-    // Add the new blocks.
-    for (blockName in networkBlocks) {
-        if(networkBlocks.hasOwnProperty(blockName)) {
-            SpriteMorph.prototype.blocks[blockName] = networkBlocks[blockName];
-        }
-    }
+    SpriteMorph.prototype.initBlocks = (function (oldInitBlocks) {
+        return function() {
+            oldInitBlocks.call(this);
+            // Add the new blocks.
+            for (blockName in networkBlocks) {
+                if(networkBlocks.hasOwnProperty(blockName)) {
+                    SpriteMorph.prototype.blocks[blockName] = networkBlocks[blockName];
+                }
+            }
+        };
+    }(SpriteMorph.prototype.initBlocks));
+    
+    SpriteMorph.prototype.initBlocks();
+    
 }());
 
 StageMorph.prototype.allNodeAttributes = SpriteMorph.prototype.allNodeAttributes = function() {

--- a/edgy/collections.js
+++ b/edgy/collections.js
@@ -473,12 +473,17 @@ SpriteMorph.prototype.reportCounterCount = function(key, counter) {
         },
     };
 
-    // Add the new blocks.
-    for (var blockName in blocks) {
-        if(blocks.hasOwnProperty(blockName)) {
-            SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
-        }
-    }
+    SpriteMorph.prototype.initBlocks = (function (oldInitBlocks) {
+        return function() {
+            oldInitBlocks.call(this);
+            // Add the new blocks.
+            for (blockName in blocks) {
+                if(blocks.hasOwnProperty(blockName)) {
+                    SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
+                }
+            }
+        };
+    }(SpriteMorph.prototype.initBlocks));
 }());
 
 /**
@@ -563,12 +568,17 @@ SpriteMorph.prototype.removeFromDict = function(key, dict) {
         }
     };
 
-    // Add the new blocks.
-    for (var blockName in blocks) {
-        if(blocks.hasOwnProperty(blockName)) {
-            SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
-        }
-    }
+    SpriteMorph.prototype.initBlocks = (function (oldInitBlocks) {
+        return function() {
+            oldInitBlocks.call(this);
+            // Add the new blocks.
+            for (blockName in blocks) {
+                if(blocks.hasOwnProperty(blockName)) {
+                    SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
+                }
+            }
+        };
+    }(SpriteMorph.prototype.initBlocks));
 }());
 
 /**
@@ -634,12 +644,17 @@ SpriteMorph.prototype.isStackEmpty = function (list) {
         },
     };
 
-    // Add the new blocks.
-    for (var blockName in blocks) {
-        if(blocks.hasOwnProperty(blockName)) {
-            SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
-        }
-    }
+    SpriteMorph.prototype.initBlocks = (function (oldInitBlocks) {
+        return function() {
+            oldInitBlocks.call(this);
+            // Add the new blocks.
+            for (blockName in blocks) {
+                if(blocks.hasOwnProperty(blockName)) {
+                    SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
+                }
+            }
+        };
+    }(SpriteMorph.prototype.initBlocks));
 }());
 
 /**
@@ -705,12 +720,17 @@ SpriteMorph.prototype.isQueueEmpty = function (list) {
         },
     };
 
-    // Add the new blocks.
-    for (var blockName in blocks) {
-        if(blocks.hasOwnProperty(blockName)) {
-            SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
-        }
-    }
+    SpriteMorph.prototype.initBlocks = (function (oldInitBlocks) {
+        return function() {
+            oldInitBlocks.call(this);
+            // Add the new blocks.
+            for (blockName in blocks) {
+                if(blocks.hasOwnProperty(blockName)) {
+                    SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
+                }
+            }
+        };
+    }(SpriteMorph.prototype.initBlocks));
 }());
 
 /**
@@ -1061,12 +1081,17 @@ SpriteMorph.prototype.isPQueueEmpty = function(pqueue) {
         },
     };
 
-    // Add the new blocks.
-    for (var blockName in blocks) {
-        if(blocks.hasOwnProperty(blockName)) {
-            SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
-        }
-    }
+    SpriteMorph.prototype.initBlocks = (function (oldInitBlocks) {
+        return function() {
+            oldInitBlocks.call(this);
+            // Add the new blocks.
+            for (blockName in blocks) {
+                if(blocks.hasOwnProperty(blockName)) {
+                    SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
+                }
+            }
+        };
+    }(SpriteMorph.prototype.initBlocks));
 }());
 
 /**
@@ -1076,6 +1101,7 @@ Add the collection categories.
 (function() {
     SpriteMorph.prototype.categories.push('collections');
     SpriteMorph.prototype.blockColor.collections = new Color(74, 108, 212);
+    SpriteMorph.prototype.initBlocks();
 }());
 
 SpriteMorph.prototype.blockTemplates = (function blockTemplates (oldBlockTemplates) {

--- a/gui.js
+++ b/gui.js
@@ -1730,7 +1730,6 @@ IDE_Morph.prototype.refreshIDE = function () {
 // IDE_Morph settings persistance
 
 IDE_Morph.prototype.applySavedSettings = function () {
-    this.removeSetting('zoom'); //FIXME: This is part of a quick fix for the zoom bug (Issue #240) , remove this line once the issue is properly dealt with.
     var design = this.getSetting('design'),
         zoom = this.getSetting('zoom'),
         language = this.getSetting('language'),
@@ -2132,10 +2131,10 @@ IDE_Morph.prototype.settingsMenu = function () {
     );
     menu.addLine();
     menu.addItem('Language...', 'languageMenu');
-    /*menu.addItem(
+    menu.addItem(
         'Zoom blocks...',
         'userSetBlocksScale'
-    );*/ // FIXME: This is just a part of a quick solution to the zooming bug (Issue #240). Once properly dealt with, un-comment this call.
+    );
     menu.addItem(
         'Stage size...',
         'userSetStageSize'


### PR DESCRIPTION
This allows the zoom blocks and language options to work correctly.
At the moment they cause errors because they call `initBlocks` and end up deleting all the Edgy-specific block definitions.

Closes #240.