### PR TITLE
Load es6-shim.js first

### DIFF
--- a/edgy.html
+++ b/edgy.html
@@ -4,6 +4,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<title>Snap! Build Your Own Blocks. Beta</title>
         <link rel="shortcut icon" href="k5_logo.png" type="image/gif">
+		<script type="text/javascript" src="es6-shim.js"></script>
 		<script type="text/javascript" src="d3.v3.js"></script>
 		<script type="text/javascript" src="cola.v2.min.js"></script>
 		<script type="text/javascript" src="jsnetworkx.js"></script>
@@ -26,7 +27,6 @@
 	</head>
 	<body style="margin: 0;">
 		<canvas id="world" tabindex="1" style="position: absolute;" />
-		<script type="text/javascript" src="es6-shim.js"></script>
 		<script type="text/javascript" src="edgy/changesToBlocks.js"></script>
 		<script type="text/javascript" src="edgy/changesToObjects.js"></script>
 		<script type="text/javascript" src="edgy/changesToStore.js"></script>


### PR DESCRIPTION
Fixes errors in Firefox regarding Array..prototype.map,
Hopefully this doesn't cause side-effects in other browsers. As far as I can tell, it shouldn't.

Closes #325.