### PR TITLE
Adds import/export of Lists and Dictionaries as CSV

### DIFF
--- a/ucsv-1.1.0.js
+++ b/ucsv-1.1.0.js
@@ -190,9 +190,14 @@ var CSV = (function () {
 				// Add the current field to the current row
 				row.push(field);
 				// If this is EOR append row to output and flush row
-				if (cur === "\n" || (cur === "\r" && s.charAt(i + 1) === "\n")) {
+				if (cur === "\n") {
 					out.push(row);
 					row = [];
+				}
+				else if ((cur === "\r" && s.charAt(i + 1) === "\n")) {
+					out.push(row);
+					row = [];
+					i++; // \r\n required two characters
 				}
 				// Flush the field buffer
 				field = '';


### PR DESCRIPTION
When right-clicking a variable watcher, the user is able to import  export a dictionary/list using the CSV format.

Also fixes a small error in the handling of \r\n line breaks (previously caused blank rows to be added erroneously).

Closes #334.