### PR TITLE
Use correct count for serialization of pqueue

### DIFF
--- a/edgy/collections.js
+++ b/edgy/collections.js
@@ -830,7 +830,8 @@ PQueue.prototype.toArray = function() {
 
 PQueue.prototype.toXML = function (serializer, mediaContext) {
     var xml = '';
-    this.items.slice(1).forEach(function(entry) {
+    for (var i = 1; i <= this.count; i++) {
+        var entry = this.items[i];
         var element = entry.element;
         var priority = entry.priority;
         
@@ -853,7 +854,7 @@ PQueue.prototype.toXML = function (serializer, mediaContext) {
         );
         
         xml += e + p;
-    });
+    };
     
     return serializer.format('<pqueue type="@">%</pqueue>', this.type || 'max', xml);
 };


### PR DESCRIPTION
Only serialize elements up to `PQueue.count`, since array elements may exist beyond that, but are not actually part of the priority queue (they remain after dequeuing elements since the underlying array does not shrink).

Fixes #396.