### PR TITLE
Fix incompatibility with Internet Explorer

### DIFF
--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -1742,12 +1742,14 @@ SpriteMorph.prototype.isCyclic = function() {
             return e instanceof jsnx.JSNetworkXUnfeasible;
         }
     } else {
-        var iter = this.G.nodesIter(),
+        var nodes = this.G.nodes(),
             visited = new Set(),
             hasCycle = false,
             stack, node, pred;
 
-        for (node of iter) {
+        for (var i = 0; i < nodes.length; i++) {
+            node = nodes[i];
+            
             if(visited.has(node))
                 continue;
 


### PR DESCRIPTION
`for..of` loops don't seem to work in IE and make the browser refuse to load the script (frustratingly, without even bothering to report an error most of the time).

This should allow Edgy to start on Internet Explorer (but I'm somewhat doubtful that everything works correctly - I'd advise to export projects frequently in case something goes wrong).