### PR TITLE
Add support for semicolon delimited CSVs

### DIFF
--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -3851,7 +3851,7 @@ function parseDot(string) {
 }
 
 function parseAdjacencyList (list) {
-    var G = jsnx.DiGraph(),
+    var G = new jsnx.DiGraph(),
         row;
 
     for (var i = 0; i < list.length; i++) {
@@ -3869,7 +3869,7 @@ function parseAdjacencyList (list) {
 }
 
 function parseAdjacencyMatrix (mat) {
-    var G = jsnx.DiGraph(),
+    var G = new jsnx.DiGraph(),
         row, a, b, label_;
 
     for (var i = 1; i < mat[0].length; i++) {
@@ -3879,7 +3879,7 @@ function parseAdjacencyMatrix (mat) {
     for (var i = 1; i < mat.length; i++) {
         row = mat[i];
         for (var j = 1; j < row.length; j++) {
-            if(row[j] !== null && row[j] !== '') {
+            if(row[j] !== null && row[j] !== '' && row[j] !== 0) {
                 a = parseNode(row[0].toString());
                 b = parseNode(mat[0][j].toString());
                 label_ = row[j].toString();

--- a/ucsv-1.1.0.js
+++ b/ucsv-1.1.0.js
@@ -185,7 +185,7 @@ var CSV = (function () {
 			cur = s.charAt(i);
 
 			// If we are at a EOF or EOR
-			if (inQuote === false && (cur === ',' || cur === "\r" || cur === "\n")) {
+			if (inQuote === false && (cur === ',' || cur === ';' || cur === "\r" || cur === "\n")) {
 				field = processField(field);
 				// Add the current field to the current row
 				row.push(field);


### PR DESCRIPTION
Gephi is able to export CSV adjacency matrices and adjacency lists through `File -> Export -> Graph File....`.

However, Gephi generates CSV files that are actually delimited by semicolons (`;`) not commas.

Also fixes some issues with parsing adjacency matrices and lists on some browsers.

Closes #415.