### PR TITLE
Refactor Snap! edits into changesets

### DIFF
--- a/byob.js
+++ b/byob.js
@@ -717,12 +717,6 @@ CustomCommandBlockMorph.prototype.mouseClickLeft = function () {
     this.edit();
 };
 
-function hashPassword(password, salt) {
-    // SHA-512 is *not* a good way of hashing passwords, but key
-    // derivation functions are painfully slow in JavaScript.
-    return hex_sha512(salt + password);
-}
-
 CustomCommandBlockMorph.prototype.edit = function () {
     var myself = this, editor, block, hat;
 
@@ -747,23 +741,6 @@ CustomCommandBlockMorph.prototype.edit = function () {
             myself.world(),
             block.fullImage(),
             myself.isInUse()
-        );
-    } else if (this.definition.password !== undefined) {
-        new DialogBoxMorph(null, function receivePassword(password) {
-            if(myself.definition.password === hashPassword(password,
-                myself.definition.salt)) {
-                new BlockEditorMorph(myself.definition, myself.receiver()).popUp();
-            } else {
-                new DialogBoxMorph(null, receivePassword).prompt(
-                    'Invalid password', '',
-                    myself.world(),
-                    new TextMorph('Invalid password.\nEnter correct '
-                        + 'password to view how this block works.'));
-            }
-        }).prompt(
-            'Password protected block', '',
-            this.world(),
-            new TextMorph('Enter password to view how this block works.')
         );
     } else {
         Morph.prototype.trackChanges = false;
@@ -1867,11 +1844,9 @@ BlockEditorMorph.prototype.init = function (definition, target) {
 
     this.addBody(scriptsFrame);
     this.addButton('ok', 'OK');
-
     if (!isLive) {
         this.addButton('updateDefinition', 'Apply');
         this.addButton('cancel', 'Cancel');
-        this.addButton('protect', 'Protect');
     }
 
     this.setExtent(new Point(375, 300)); // normal initial extent
@@ -1982,26 +1957,6 @@ BlockEditorMorph.prototype.close = function () {
     }
 
     this.destroy();
-};
-
-BlockEditorMorph.prototype.protect = function ()
-{
-    var myself = this;
-    console.log(this.definition);
-    new DialogBoxMorph(null, function (password) {
-        if(password) {
-            myself.definition.salt = (new Date()).toString();
-            myself.definition.password = hashPassword(password, myself.definition.salt);
-        } else {
-            delete myself.definition.salt;
-            delete myself.definition.password;
-        }
-    }).prompt(
-        'Password protect block', '',
-        this.world(),
-        new TextMorph('Enter a password to protect this block\'s contents ' +
-        'from being viewed/edited.\nLeave blank to remove any existing ' +
-        'password.'));
 };
 
 BlockEditorMorph.prototype.consolidateDoubles = function () {

--- a/edgy.html
+++ b/edgy.html
@@ -29,6 +29,7 @@
 	<body style="margin: 0;">
 		<canvas id="world" tabindex="1" style="position: absolute;" />
 		<script type="text/javascript" src="edgy/changesToBlocks.js"></script>
+		<script type="text/javascript" src="edgy/changesToThreads.js"></script>
 		<script type="text/javascript" src="edgy/changesToObjects.js"></script>
 		<script type="text/javascript" src="edgy/changesToStore.js"></script>
 		<script type="text/javascript" src="edgy/changesToGui.js"></script>

--- a/edgy/changesToObjects.js
+++ b/edgy/changesToObjects.js
@@ -941,7 +941,7 @@ Costume.prototype.edit = (function edit(oldEdit) {
 }(Costume.prototype.edit));
 
 function autoNumericize(x) {
-    return isNumeric(x) ? parseFloat(x) : x;
+    return !isNaN(parseFloat(x)) && isFinite(x) ? parseFloat(x) : x;
 }
 
 function parseNode(node) {
@@ -4340,6 +4340,48 @@ WatcherMorph.prototype.userMenu = (function (oldUserMenu) {
         return menu;
     };
 }(WatcherMorph.prototype.userMenu));
+
+StageMorph.prototype.fireGreenFlagEvent = (function(oldFireGreenFlagEvent) {
+    return function() {
+        clickstream.log("fireGreenFlag");
+        return oldFireGreenFlagEvent.call(this);
+    };
+}(StageMorph.prototype.fireGreenFlagEvent));
+
+var variableBlocks = {
+    doConcatToList : {
+        type: 'command',
+        category: 'lists',
+        spec: 'concatenate %l to %l',
+    },
+    doListJoin : {
+        type: 'reporter',
+        category: 'lists',
+        spec: '%l and %l joined',
+    },
+    getRandomFromList: {
+        type: 'reporter',
+        category: 'lists',
+        spec: 'random item from %l'
+    },
+    getClone: {
+        type: 'reporter',
+        category: 'lists',
+        spec: 'clone %l'
+    },
+};
+
+SpriteMorph.prototype.initBlocks = (function (oldInitBlocks) {
+    return function() {
+        oldInitBlocks.call(this);
+        // Add the new blocks.
+        for (blockName in variableBlocks) {
+            if(variableBlocks.hasOwnProperty(blockName)) {
+                SpriteMorph.prototype.blocks[blockName] = blocks[blockName];
+            }
+        }
+    };
+}(SpriteMorph.prototype.initBlocks));
 
 (function() {
     var alternatives = {

--- a/edgy/changesToThreads.js
+++ b/edgy/changesToThreads.js
@@ -1,0 +1,120 @@
+(function() {
+"use strict";
+
+ThreadManager.prototype.startProcess = (function(oldStartProcess) {
+    return function (
+        block,
+        isThreadSafe,
+        exportResult,
+        callback,
+        isClicked,
+        rightAway
+    ) {
+        oldStartProcess.call(this, block, isThreadSafe, exportResult, callback, isClicked, rightAway);
+        clickstream.log("startProcess", {blockId: block.topBlock().blockID});
+    };
+}(ThreadManager.prototype.startProcess));
+
+
+ThreadManager.prototype.stopAll = (function(oldStopAll) {
+    return function (excpt) {
+        clickstream.log("stopAll");
+        return oldStopAll.call(this, excpt);
+    };
+}(ThreadManager.prototype.stopAll));
+
+ThreadManager.prototype.resumeAll = (function(oldResumeAll) {
+    return function (stage) {
+        clickstream.log("resumeAll");
+        return oldResumeAll.call(this, stage);
+    };
+}(ThreadManager.prototype.resumeAll));
+
+Process.prototype.reportJSFunction = (function(oldReportJSFunction) {
+    return function (parmNames, body) {
+        if (window.javascriptexecutionlevel === 'full') {
+            return oldReportJSFunction.call(this, parmNames, body);
+        }
+        else {
+            throw new Error([
+                'The current script attempted to execute JavaScript code at a higher privilege level than is currently allowed.',
+                'Code execution was terminated.',
+                'If you trust the code within the JavaScript blocks and wish to execute it, set the "Execution level" setting to the appropriate level.'
+            ].join('\n'));
+        }
+    };
+}(Process.prototype.reportJSFunction));
+
+Process.prototype.evaluate = (function(oldEvaluate) {
+    return function (
+        context,
+        args,
+        isCommand
+    ) {
+        if (context instanceof Function && window.javascriptexecutionlevel !== 'full') {
+            throw new Error([
+                'The current script attempted to execute JavaScript code at a higher privilege level than is currently allowed.',
+                'Code execution was terminated.',
+                'If you trust the code within the JavaScript blocks and wish to execute it, set the "Execution level" setting to the appropriate level.'
+            ].join('\n'));
+        }
+        else {
+            return oldEvaluate.call(this, context, args, isCommand);
+        }
+    };
+}(Process.prototype.evaluate));
+
+
+Process.prototype.doConcatToList = function (l, list) {
+    list.becomeArray();
+    l.becomeArray();
+    list.contents = list.contents.concat(l.contents);
+};
+
+Process.prototype.getRandomFromList = function (l) {
+    var idx = Math.floor(Math.random() * l.length()) + 1;
+    // Handle any accidental mis-rounding; should be rare: "on the order of one
+    // in 2^62" according to
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random)
+    return l.at(Math.min(idx, l.length()));
+}
+
+function snapClone(o, memo) {
+    memo = memo || new Map();
+
+    if(memo.has(o)) {
+        return memo.get(o);
+    }
+
+    if(o instanceof List) {
+        var c = new List(o.asArray().map(function(x) {
+            return snapClone(x, memo);
+        }));
+        memo.set(o, c);
+        return c;
+    } else if(o instanceof Map) {
+        var l = [];
+        o.forEach(function(v, k) {
+            l.push([snapClone(k, memo), snapClone(v, memo)]);
+        });
+        var c = new Map(l);
+        memo.set(o, c);
+        return c;
+    } else if(typeof o == "number" || typeof o == "string" || typeof o == "boolean") {
+        return o;
+    } else {
+        throw new Error("Encountered object of unknown type.");
+    }
+}
+
+Process.prototype.getClone = function (l) {
+    return snapClone(l);
+}
+
+Process.prototype.doListJoin = function (a, b) {
+    a.becomeArray();
+    b.becomeArray();
+    return new List(a.contents.concat(b.contents));
+};
+
+}());

--- a/gui.js
+++ b/gui.js
@@ -256,6 +256,7 @@ IDE_Morph.prototype.init = function (isAutoFill) {
     this.color = this.backgroundColor;
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 IDE_Morph.prototype.openIn = function (world) {
     var hash, usr, myself = this, urlLanguage = null;
 
@@ -1660,23 +1661,9 @@ IDE_Morph.prototype.fixLayout = function (situation) {
 };
 
 IDE_Morph.prototype.setProjectName = function (string) {
-    var newName = string.replace(/['"]/g, ''); // filter quotation marks
-    if(newName !== this.projectName) {
-        clickstream.log("set_project_name", {name: string});
-        this.setProjectId();
-    }
-    this.projectName = newName;
+    this.projectName = string.replace(/['"]/g, ''); // filter quotation marks
     this.hasChangedMedia = true;
     this.controlBar.updateLabel();
-};
-
-IDE_Morph.prototype.setProjectId = function (id) {
-    if(id === undefined) {
-        this.projectId = uuid.v1();
-        clickstream.log("set_project_id", {id: this.projectId});
-    } else {
-        this.projectId = id;
-    }
 };
 
 // IDE_Morph resizing
@@ -1789,9 +1776,6 @@ IDE_Morph.prototype.droppedText = function (aString, name) {
     }
     if (aString.indexOf('<blocks') === 0) {
         return this.openBlocksString(aString, lbl, true);
-    }
-	if (aString.indexOf('<variables') === 0) {
-        return this.openVariablesString(aString);
     }
     if (aString.indexOf('<sprites') === 0) {
         return this.openSpritesString(aString);
@@ -1998,9 +1982,6 @@ IDE_Morph.prototype.applySavedSettings = function () {
         tableLines = this.getSetting('tableLines'),
         autoWrapping = this.getSetting('autowrapping');
 
-    // Principle of least privilege: JavaScript block execution is disabled unless the user requires it for this particular session.
-    window.javascriptexecutionlevel = 'blocked';
-    
     // design
     if (design === 'flat') {
         this.setFlatDesign();
@@ -2384,6 +2365,7 @@ IDE_Morph.prototype.cloudMenu = function () {
     menu.popup(world, pos);
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 IDE_Morph.prototype.settingsMenu = function () {
     var menu,
         stage = this.stage,
@@ -2789,6 +2771,7 @@ IDE_Morph.prototype.settingsMenu = function () {
     menu.popup(world, pos);
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 IDE_Morph.prototype.projectMenu = function () {
     var menu,
         myself = this,
@@ -3466,31 +3449,6 @@ IDE_Morph.prototype.rawSaveProject = function (name) {
     }
 };
 
-IDE_Morph.prototype.saveProjectToDisk = function (plain) {
-    var data,
-        link = document.createElement('a'),
-        href = 'data:text/' + (plain ? 'plain' : 'xml') + ',';
-
-    if (Process.prototype.isCatchingErrors) {
-        try {
-            data = encodeURIComponent(this.serializer.serialize(this.stage));
-            link.setAttribute('href', href + data);
-            link.setAttribute('download', this.projectName + '.xml');
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-        } catch (err) {
-            this.showMessage('Saving failed: ' + err);
-        }
-    } else {
-        data = encodeURIComponent(this.serializer.serialize(this.stage));
-        link.setAttribute('href', href + data);
-        link.setAttribute('download', this.projectName + '.xml');
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-    }
-};
 
 IDE_Morph.prototype.exportProject = function (name, plain, newWindow) {
     // Export project XML, saving a file to disk
@@ -3499,7 +3457,6 @@ IDE_Morph.prototype.exportProject = function (name, plain, newWindow) {
 
     if (name) {
         this.setProjectName(name);
-
         dataPrefix = 'data:text/' + plain ? 'plain,' : 'xml,';
         try {
             menu = this.showMessage('Exporting');
@@ -3515,7 +3472,6 @@ IDE_Morph.prototype.exportProject = function (name, plain, newWindow) {
                 throw err;
             }
         }
-
     }
 };
 
@@ -4604,21 +4560,6 @@ IDE_Morph.prototype.languageMenu = function () {
     });
     menu.popup(world, pos);
 };
-
-IDE_Morph.prototype.javaScriptExecutionLevelMenu = function() {
-    var menu = new MenuMorph(this),
-        world = this.world(),
-        pos = this.controlBar.settingsButton.bottomLeft(),
-        myself = this;
-    menu.addItem((window.javascriptexecutionlevel === 'full' ? '\u2713 ' : '    ')+'full', function() {
-        alert('You have given the current project permission to execute code at the same level as Edgy itself -- code within "JavaScript function" blocks will have access to all Edgy functionality, including modifying local storage and accessing cloud storage credentials. If you do not trust the author of this project, set the "Execution privileges" permission setting to a lower value.');
-        window.javascriptexecutionlevel = 'full';
-    });
-    menu.addItem((window.javascriptexecutionlevel === 'blocked' ? '\u2713 ' : '    ')+'blocked', function() {
-        window.javascriptexecutionlevel = 'blocked'; }
-    );
-    menu.popup(world, pos);
-}
 
 IDE_Morph.prototype.setLanguage = function (lang, callback) {
     var translation = document.getElementById('language'),

--- a/objects.js
+++ b/objects.js
@@ -1689,6 +1689,7 @@ SpriteMorph.prototype.variableBlock = function (varName) {
 
 // SpriteMorph block templates
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 SpriteMorph.prototype.blockTemplates = function (category) {
     var blocks = [], myself = this, varNames, button,
         cat = category || 'motion', txt,
@@ -2232,6 +2233,7 @@ SpriteMorph.prototype.palette = function (category) {
     return this.paletteCache[category];
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 SpriteMorph.prototype.freshPalette = function (category) {
     var palette = new ScrollFrameMorph(null, null, this.sliderColor),
         unit = SyntaxElementMorph.prototype.fontSize,
@@ -4508,6 +4510,7 @@ SpriteMorph.prototype.doubleDefinitionsFor = function (definition) {
     });
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 SpriteMorph.prototype.replaceDoubleDefinitionsFor = function (definition) {
     var doubles = this.doubleDefinitionsFor(definition),
         myself = this,
@@ -5712,7 +5715,7 @@ StageMorph.prototype.fireGreenFlagEvent = function () {
     if (ide) {
         ide.controlBar.pauseButton.refresh();
     }
-    clickstream.log("fireGreenFlag");
+
     return procs;
 };
 
@@ -5771,6 +5774,7 @@ StageMorph.prototype.editScripts = function () {
 
 // StageMorph block templates
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 StageMorph.prototype.blockTemplates = function (category) {
     var blocks = [], myself = this, varNames, button,
         cat = category || 'motion', txt;
@@ -6988,6 +6992,7 @@ Costume.prototype.flipped = function () {
 
 // Costume actions
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 Costume.prototype.edit = function (aWorld, anIDE, isnew, oncancel, onsubmit) {
     var myself = this,
         editor = new PaintEditorMorph();

--- a/store.js
+++ b/store.js
@@ -331,6 +331,7 @@ SnapSerializer.prototype.loadProjectModel = function (xmlNode, ide) {
     return this.rawLoadProjectModel(xmlNode);
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 SnapSerializer.prototype.rawLoadProjectModel = function (xmlNode) {
     // private
     var myself = this,
@@ -792,6 +793,7 @@ SnapSerializer.prototype.loadVariables = function (varFrame, element) {
     });
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 SnapSerializer.prototype.loadCustomBlocks = function (
     object,
     element,
@@ -1133,23 +1135,6 @@ SnapSerializer.prototype.loadInput = function (model, input, block) {
             );
         });
         input.fixLayout();
-    } else if (model.tag === 'pairs') {
-        while (input.inputs().length > 0) {
-            input.removeInput();
-        }
-		var i = 0;
-        model.children.forEach(function (item) {
-            if (i % 2 == 0) {
-				input.addInput();
-            }
-			myself.loadInput(
-                item,
-                input.children[input.children.length - 3 + (i % 2)],
-                input
-            );
-			i++;
-        });
-        input.fixLayout();
     } else if (model.tag === 'block' || model.tag === 'custom-block') {
         block.silentReplaceInput(input, this.loadBlock(model, true));
     } else if (model.tag === 'color') {
@@ -1246,48 +1231,6 @@ SnapSerializer.prototype.loadValue = function (model) {
             return myself.loadValue(value);
         });
         return v;
-    case 'map':
-        var res = new Map();
-        var myself = this;
-        var keys = model.childrenNamed('key').map(function (item) {
-            var value = item.children[0];
-            if (!value) {
-                return 0;
-            }
-            return myself.loadValue(value);
-        });
-        var values = model.childrenNamed('value').map(function (item) {
-            var value = item.children[0];
-            if (!value) {
-                return 0;
-            }
-            return myself.loadValue(value);
-        });
-        for (var i = 0; i < keys.length; i++) {
-            res.set(keys[i], values[i]);
-        }
-        return res;
-    case 'pqueue':
-        var type = model.attributes.type;
-        var elements = model.childrenNamed('element').map(function (item) {
-            var value = item.children[0];
-            if (!value) {
-                return 0;
-            }
-            return myself.loadValue(value);
-        });
-        var priorities = model.childrenNamed('priority').map(function (item) {
-            var value = item.children[0];
-            if (!value) {
-                return 0;
-            }
-            return myself.loadValue(value);
-        });
-        var entries = [];
-        for (var i = 0; i < elements.length; i++) {
-            entries.push(new Entry(elements[i], priorities[i]));
-        }
-        return new PQueue(entries, type);
     case 'sprite':
         v  = new SpriteMorph(myself.project.globalVariables);
         if (model.attributes.id) {
@@ -1470,6 +1413,7 @@ SnapSerializer.prototype.loadColor = function (colorString) {
     );
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 SnapSerializer.prototype.openProject = function (project, ide) {
     var stage = ide.stage,
         sprites = [],
@@ -1529,6 +1473,7 @@ Array.prototype.toXML = function (serializer) {
 
 // Sprites
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 StageMorph.prototype.toXML = function (serializer) {
     var thumbnail = normalizeCanvas(
             this.thumbnail(SnapSerializer.prototype.thumbnailSize),
@@ -1625,6 +1570,7 @@ StageMorph.prototype.toXML = function (serializer) {
     );
 };
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 SpriteMorph.prototype.toXML = function (serializer) {
     var stage = this.parentThatIsA(StageMorph),
         ide = stage ? stage.parentThatIsA(IDE_Morph) : null,
@@ -1908,6 +1854,7 @@ CustomCommandBlockMorph.prototype.toBlockXML = function (serializer) {
 CustomReporterBlockMorph.prototype.toBlockXML
     = CustomCommandBlockMorph.prototype.toBlockXML;
 
+// NOTE: This function may cause merge conflicts with the Snap! repository.
 CustomBlockDefinition.prototype.toXML = function (serializer) {
     var myself = this;
 


### PR DESCRIPTION
Refactor Snap! edits into changesets as per #370. It may be wise to merge this into its own branch rather than master in case there are unforeseen bugs caused by this.

Not all changes could be moved to the changeset files, but each function which might cause a merge conflict is now marked with a comment so that the changes can be kept track of.

- Refactors blocks.js to be identical to upstream Snap! file.
- Refactors byob.js to be identical to upstream Snap! file.
- Refactors some of the changes in gui.js into changesToGui.js. Areas
that still differ have been marked with comments.
- Refactors threads.js to be identical to upstream Snap! file.
- Refactors some of the changes in objects.js into changesToObjects.js. Areas
that still differ have been marked with comments.
- Refactors some of the changes in store.js into changesToStore.js. Areas
that still differ have been marked with comments.

Closes #370.