### PR TITLE
Return value for `ThreadManager.prototype.startProcess`

### DIFF
--- a/edgy/changesToThreads.js
+++ b/edgy/changesToThreads.js
@@ -10,7 +10,7 @@ ThreadManager.prototype.startProcess = (function(oldStartProcess) {
         isClicked,
         rightAway
     ) {
-        oldStartProcess.call(this, block, isThreadSafe, exportResult, callback, isClicked, rightAway);
+        return oldStartProcess.call(this, block, isThreadSafe, exportResult, callback, isClicked, rightAway);
         clickstream.log("startProcess", {blockId: block.topBlock().blockID});
     };
 }(ThreadManager.prototype.startProcess));


### PR DESCRIPTION
Returns the correct value for `ThreadManager.prototype.startProcess`.

Closes #431