### PR TITLE
Define `myself` at the correct location when deserializing collections

### DIFF
--- a/edgy/changesToStore.js
+++ b/edgy/changesToStore.js
@@ -31,10 +31,10 @@ SnapSerializer.prototype.loadInput = (function(oldLoadInput) {
 
 SnapSerializer.prototype.loadValue = (function(oldLoadValue) {
     return function (model) {
+        var myself = this;
         switch (model.tag) {
             case 'map':
                 var res = new Map();
-                var myself = this;
                 var keys = model.childrenNamed('key').map(function (item) {
                     var value = item.children[0];
                     if (!value) {


### PR DESCRIPTION
Moves the line defining `myself` to before it is used in the switch statement for loading dictionaries and priority queues.

Fixes an issue with loading priority queues.