### PR TITLE
Fix List.toString() returning function instead of length (Fixes #441)

### DIFF
--- a/lists.js
+++ b/lists.js
@@ -119,7 +119,7 @@ List.prototype.enableTables = false; // default, to not confuse NYC teachers
 // List printing
 
 List.prototype.toString = function () {
-    return 'a List [' + this.length + ' elements]';
+    return 'a List [' + this.length() + ' elements]';
 };
 
 // List updating:


### PR DESCRIPTION
```
List.prototype.toString = function () {
    return 'a List [' + this.length + ' elements]';
};
```
this.length Was missing a  () so it returned the code of the function instead.

This should fix issues with behaviour such as displaying a node attribute when it is a list resulting in the implementation code instead of the expected result of : "a List[ n elements]" (fixes #441 )

![example](https://i.imgur.com/4swAKeg.png)

to 

![fixedexample](https://i.imgur.com/5dzow1N.png)