### PR TITLE
Change window.open to saveAs

### DIFF
--- a/edgy/changesToBlocks.js
+++ b/edgy/changesToBlocks.js
@@ -265,7 +265,8 @@ BlockMorph.prototype.userMenu = (function(oldUserMenu) {
                     var exportSequence = function() {
                         var serializer = new SnapSerializer();
                         var xml = myself.topBlock().toScriptXML(serializer);
-                        window.open("data:text/xml," + xml);
+                        var blob = new Blob([xml], {type: "text/xml"});
+                        saveAs(blob, "blocks.xml");
                     };
                     
                     // Test if a block contains/is a custom block


### PR DESCRIPTION
Fixes an issue where exported block sequences only opened a blank page.

Closes #446.

`window.open` no longer works correctly for XML data URLs.
Instead, `saveAs` from `fileSaver` is used (consistent with the rest of Snap!).