### PR TITLE
Change saveCanvasAs to use FileSaver

### DIFF
--- a/edgy/changesToGui.js
+++ b/edgy/changesToGui.js
@@ -454,4 +454,8 @@ IDE_Morph.prototype.createControlBar = (function(oldCreateControlBar) {
     };
 }(IDE_Morph.prototype.createControlBar));
 
+IDE_Morph.prototype.saveCanvasAs = function (canvas, fileName, newWindow) {
+    canvas.toBlob(blob => saveAs(blob, fileName || "script.png"));
+};
+
 }());


### PR DESCRIPTION
Uses canvas built in blob to save script pics using FileSaver. Fixes #448.

It might be time to try to merge upstream [Snap](https://github.com/jmoenig/Snap) as I believe these file saving issues have been fixed there (although merging will end up being very time consuming if anything like the last time).